### PR TITLE
Updated part number content type

### DIFF
--- a/src/app/Forms/Templates/product.json
+++ b/src/app/Forms/Templates/product.json
@@ -36,7 +36,7 @@
                     "value": null,
                     "meta": {
                         "type": "input",
-                        "content": "number"
+                        "content": "text"
                     }
                 },
                 {


### PR DESCRIPTION
It was not possible to add products when freshly installed. 
Updated to text so it matches database field type.